### PR TITLE
Add Codex (OpenAI) agent support

### DIFF
--- a/apps/cli/src/commands/init/phases/create.ts
+++ b/apps/cli/src/commands/init/phases/create.ts
@@ -16,6 +16,7 @@ import {
   type AgentId,
 } from '../../../config'
 import { ensureDir, writeJsonFile, writeTextFile, fileExists } from '../../../utils/files'
+import { writeTomlFile } from '../../../utils/toml'
 import { saveGithubToken } from '../../../lib/vault'
 import { getSkillsByNames, getSkillsCount, type SkillSelection } from '../../../lib/skills'
 import { select } from '../../../utils/prompts'
@@ -119,7 +120,11 @@ export async function generateConfigsStep(context: SetupContext): Promise<void> 
     }
 
     const outputPath = join(context.skillsPath, agent.configFile)
-    await writeJsonFile(outputPath, config)
+    if (agent.configFormat === 'toml') {
+      await writeTomlFile(outputPath, config as Record<string, unknown>)
+    } else {
+      await writeJsonFile(outputPath, config)
+    }
   }
 }
 

--- a/apps/cli/src/config/agents/codex/index.ts
+++ b/apps/cli/src/config/agents/codex/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Codex Agent Definition
+ */
+
+import type { AgentDefinition } from '../types'
+
+export const codex: AgentDefinition = {
+  id: 'codex',
+  displayName: 'Codex',
+  configFile: '.codex/config.toml',
+  configFormat: 'toml',
+  baseConfigTemplate: {
+    mcp_servers: {},
+  },
+  mcpServersKey: 'mcp_servers',
+  skillsDir: '.agents/skills',
+  // Codex natively reads AGENTS.md — no separate template file needed
+  authInstructions: 'In Codex: /mcp → kappa → Authenticate',
+  cliCommand: 'codex',
+}

--- a/apps/cli/src/config/agents/index.ts
+++ b/apps/cli/src/config/agents/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { claude } from './claude'
+import { codex } from './codex'
 import { copilot } from './copilot'
 import { cursor } from './cursor'
 import { opencode } from './opencode'
@@ -19,6 +20,7 @@ export type { AgentDefinition } from './types'
  */
 export const AGENTS = {
   claude,
+  codex,
   copilot,
   cursor,
   opencode,

--- a/apps/cli/src/config/agents/types.ts
+++ b/apps/cli/src/config/agents/types.ts
@@ -18,6 +18,9 @@ export interface AgentDefinition {
   /** Output config file path (e.g., '.mcp.json', '.cursor/mcp.json') */
   configFile?: string
 
+  /** Config file format ('json' by default, 'toml' for Codex) */
+  configFormat?: 'json' | 'toml'
+
   /** Base MCP config template (contains only kappa server, MCPs are merged in) */
   baseConfigTemplate?: Record<string, unknown>
 

--- a/apps/cli/src/config/mcps/algorand-remote/index.ts
+++ b/apps/cli/src/config/mcps/algorand-remote/index.ts
@@ -26,6 +26,15 @@ function getAgentConfig(agentId: AgentId): AgentMCPConfig | undefined {
         },
       }
 
+    case 'codex':
+      return {
+        serverKey: 'algorand-remote',
+        config: {
+          command: 'npx',
+          args: ['-y', 'mcp-remote', ALGORAND_REMOTE_URL],
+        },
+      }
+
     case 'opencode':
       return {
         serverKey: 'algorand-remote',

--- a/apps/cli/src/config/mcps/context7/index.ts
+++ b/apps/cli/src/config/mcps/context7/index.ts
@@ -25,6 +25,14 @@ function getAgentConfig(agentId: AgentId): AgentMCPConfig | undefined {
         },
       }
 
+    case 'codex':
+      return {
+        serverKey: 'context7',
+        config: {
+          url: CONTEXT7_URL,
+        },
+      }
+
     case 'opencode':
       return {
         serverKey: 'context7',

--- a/apps/cli/src/config/mcps/kappa/index.ts
+++ b/apps/cli/src/config/mcps/kappa/index.ts
@@ -24,6 +24,14 @@ function getAgentConfig(agentId: AgentId): AgentMCPConfig | undefined {
         },
       }
 
+    case 'codex':
+      return {
+        serverKey: 'kappa',
+        config: {
+          url: KAPPA_URL,
+        },
+      }
+
     case 'opencode':
       return {
         serverKey: 'kappa',

--- a/apps/cli/src/config/mcps/vibekit/index.ts
+++ b/apps/cli/src/config/mcps/vibekit/index.ts
@@ -25,6 +25,16 @@ function getAgentConfig(agentId: AgentId): AgentMCPConfig | undefined {
         },
       }
 
+    case 'codex':
+      return {
+        serverKey: 'vibekit-mcp',
+        config: {
+          command: '$VIBEKIT_PATH',
+          args: ['mcp'],
+          env: '$MCP_ENV',
+        },
+      }
+
     case 'opencode':
       return {
         serverKey: 'vibekit-mcp',

--- a/apps/cli/src/utils/toml.ts
+++ b/apps/cli/src/utils/toml.ts
@@ -1,0 +1,83 @@
+/**
+ * Minimal TOML serializer for MCP config structures.
+ *
+ * Handles the subset of TOML needed for agent configs:
+ * - String, number, boolean values
+ * - Arrays of strings
+ * - Nested object sections (up to 3 levels deep)
+ */
+
+import { dirname } from 'path'
+import { ensureDir } from './files'
+import { writeFile } from 'fs/promises'
+
+function serializeValue(value: unknown): string {
+  if (typeof value === 'string') return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) return `[${value.map(serializeValue).join(', ')}]`
+  throw new Error(`Unsupported TOML value type: ${typeof value}`)
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Serialize a config object to TOML format.
+ *
+ * Produces output like:
+ * ```toml
+ * [mcp_servers.kappa]
+ * url = "https://example.com"
+ *
+ * [mcp_servers.vibekit-mcp]
+ * command = "/path/to/vibekit"
+ * args = ["mcp"]
+ *
+ * [mcp_servers.vibekit-mcp.env]
+ * KEY = "value"
+ * ```
+ */
+export function serializeToml(obj: Record<string, unknown>): string {
+  const lines: string[] = []
+
+  function writeSection(value: Record<string, unknown>, keyPath: string[]): void {
+    // Separate inline values from nested objects
+    const inlineEntries: [string, unknown][] = []
+    const nestedEntries: [string, Record<string, unknown>][] = []
+
+    for (const [k, v] of Object.entries(value)) {
+      if (isPlainObject(v)) {
+        nestedEntries.push([k, v])
+      } else {
+        inlineEntries.push([k, v])
+      }
+    }
+
+    // Write section header + inline values if there are any inline values
+    if (inlineEntries.length > 0) {
+      if (keyPath.length > 0) {
+        lines.push(`[${keyPath.join('.')}]`)
+      }
+      for (const [k, v] of inlineEntries) {
+        lines.push(`${k} = ${serializeValue(v)}`)
+      }
+      lines.push('')
+    }
+
+    // Recurse into nested objects
+    for (const [k, v] of nestedEntries) {
+      writeSection(v, [...keyPath, k])
+    }
+  }
+
+  writeSection(obj, [])
+
+  return lines.join('\n')
+}
+
+/** Write a config object to a TOML file */
+export async function writeTomlFile(filePath: string, data: Record<string, unknown>): Promise<void> {
+  await ensureDir(dirname(filePath))
+  await writeFile(filePath, serializeToml(data), 'utf-8')
+}


### PR DESCRIPTION
Add Codex as a supported AI coding agent with TOML config format (.codex/config.toml), shared skills directory (.agents/skills), and native AGENTS.md reading. Includes a minimal TOML serializer and MCP configs for all four servers.

Closes #11 