### PR TITLE
fix: prevent stack overflow in base64 encoding for large byte arrays

### DIFF
--- a/apps/mcp-server/src/lib/encoding.test.ts
+++ b/apps/mcp-server/src/lib/encoding.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { encodeBase64, bytesToBase64, decodeBase64, bytesToString } from './encoding.js'
+
+describe('encodeBase64', () => {
+  it('encodes small byte arrays', () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]) // "Hello"
+    expect(encodeBase64(bytes)).toBe('SGVsbG8=')
+  })
+
+  it('handles empty byte arrays', () => {
+    expect(encodeBase64(new Uint8Array([]))).toBe('')
+  })
+
+  it('encodes large byte arrays without stack overflow', () => {
+    // Arrays >64KB cause "Maximum call stack size exceeded" with
+    // String.fromCharCode(...bytes) due to JS engine argument limits
+    const bytes = new Uint8Array(100_000)
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = i % 256
+    }
+    expect(() => encodeBase64(bytes)).not.toThrow()
+    // Verify round-trip
+    const decoded = Buffer.from(encodeBase64(bytes), 'base64')
+    expect(new Uint8Array(decoded)).toEqual(bytes)
+  })
+})
+
+describe('bytesToBase64', () => {
+  it('returns string input unchanged', () => {
+    expect(bytesToBase64('already-base64')).toBe('already-base64')
+  })
+
+  it('encodes Uint8Array to base64', () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111])
+    expect(bytesToBase64(bytes)).toBe('SGVsbG8=')
+  })
+
+  it('encodes large byte arrays without stack overflow', () => {
+    const bytes = new Uint8Array(100_000)
+    expect(() => bytesToBase64(bytes)).not.toThrow()
+  })
+})
+
+describe('decodeBase64', () => {
+  it('decodes valid base64', () => {
+    expect(decodeBase64('SGVsbG8=')).toBe('Hello')
+  })
+
+  it('falls back to original string on invalid base64', () => {
+    expect(decodeBase64('not valid base64!!!')).toBe('not valid base64!!!')
+  })
+})
+
+describe('bytesToString', () => {
+  it('decodes Uint8Array as UTF-8', () => {
+    const bytes = new TextEncoder().encode('Hello')
+    expect(bytesToString(bytes)).toBe('Hello')
+  })
+
+  it('decodes base64 string input', () => {
+    expect(bytesToString('SGVsbG8=')).toBe('Hello')
+  })
+})

--- a/apps/mcp-server/src/lib/encoding.ts
+++ b/apps/mcp-server/src/lib/encoding.ts
@@ -36,12 +36,12 @@ export function bytesToBase64(bytes: Uint8Array | string): string {
   if (typeof bytes === 'string') {
     return bytes
   }
-  return btoa(String.fromCharCode(...bytes))
+  return Buffer.from(bytes).toString('base64')
 }
 
 /**
  * Encode a Uint8Array to base64.
  */
 export function encodeBase64(bytes: Uint8Array): string {
-  return btoa(String.fromCharCode(...new Uint8Array(bytes)))
+  return Buffer.from(bytes).toString('base64')
 }


### PR DESCRIPTION
## Summary

- Replace `btoa(String.fromCharCode(...bytes))` with `Buffer.from(bytes).toString('base64')` in both `encodeBase64` and `bytesToBase64` to prevent "Maximum call stack size exceeded" on arrays larger than ~64KB
- Add test coverage for all encoding utility functions, including a 100KB round-trip test that verifies the fix

## Problem

`String.fromCharCode(...bytes)` uses the spread operator to pass every byte as a separate argument. JavaScript engines impose a limit on the number of function arguments (typically ~65,536), so any `Uint8Array` larger than ~64KB causes a `RangeError: Maximum call stack size exceeded`.

This affects `encodeBase64` (used in `read_box` and `app_get_info` tools) and `bytesToBase64`, meaning any application with a large approval program or large box value would crash the MCP server.

## Fix

Use `Buffer.from(bytes).toString('base64')` which handles arbitrary-length arrays efficiently without argument spreading. This is safe since the MCP server runs in Node.js.

## Test plan

- [x] Added `encoding.test.ts` with 10 tests covering all four encoding functions
- [x] Includes a 100,000-byte array test that would crash before the fix
- [x] All tests pass locally with `vitest`

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)