### PR TITLE
fix: add runtime validation for parseArgs tool arguments

### DIFF
--- a/apps/mcp-server/src/tools/index.ts
+++ b/apps/mcp-server/src/tools/index.ts
@@ -8,7 +8,7 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js'
 import type { AlgorandClient } from '@algorandfoundation/algokit-utils'
 import type { McpConfig } from '../config.js'
 import type { ToolContext, ToolHandler, ToolRegistration } from './types.js'
-import { isResultWithImage } from './types.js'
+import { isResultWithImage, validateArgs } from './types.js'
 
 import { contractTools } from './contracts/index.js'
 import { stateTools } from './state/index.js'
@@ -45,6 +45,11 @@ const handlers: Record<string, ToolHandler> = Object.fromEntries(
   allToolRegistrations.map((t) => [t.definition.name, t.handler])
 )
 
+// Build schema map for argument validation
+const schemas: Record<string, Tool['inputSchema']> = Object.fromEntries(
+  allToolRegistrations.map((t) => [t.definition.name, t.definition.inputSchema])
+)
+
 // MCP content block types
 type TextContent = { type: 'text'; text: string }
 type ImageContent = { type: 'image'; data: string; mimeType: string }
@@ -76,6 +81,13 @@ export async function handleToolCall(
     const handler = handlers[name]
     if (!handler) {
       throw new Error(`Unknown tool: ${name}`)
+    }
+
+    // Validate arguments against the tool's inputSchema before dispatching.
+    // Catches malformed AI-generated arguments early with clear error messages.
+    const schema = schemas[name]
+    if (schema) {
+      validateArgs(args, schema, name)
     }
 
     const ctx: ToolContext = { algorand, config }

--- a/apps/mcp-server/src/tools/types.ts
+++ b/apps/mcp-server/src/tools/types.ts
@@ -38,9 +38,70 @@ export interface ToolRegistration {
 /**
  * Parse tool arguments with type assertion.
  * Reduces boilerplate of `args as unknown as T` pattern.
+ *
+ * Note: structural validation happens in handleToolCall() before handlers
+ * are invoked. This cast is safe because args have already been validated
+ * against the tool's inputSchema.
  */
 export function parseArgs<T>(args: Record<string, unknown>): T {
   return args as unknown as T
+}
+
+/** JSON Schema type for tool inputSchema definitions. */
+interface JsonSchema {
+  type: string
+  properties?: Record<string, { type?: string | string[]; description?: string }>
+  required?: string[]
+}
+
+/**
+ * Validate tool arguments against the tool's inputSchema.
+ *
+ * Checks required fields are present and property types match schema.
+ * Catches malformed AI-generated arguments early with clear error messages
+ * instead of letting them propagate as cryptic runtime errors.
+ *
+ * @throws Error with a descriptive message listing all validation failures
+ */
+export function validateArgs(
+  args: Record<string, unknown>,
+  schema: JsonSchema,
+  toolName: string
+): void {
+  const errors: string[] = []
+
+  // Check required fields
+  if (schema.required) {
+    for (const field of schema.required) {
+      if (args[field] === undefined || args[field] === null) {
+        errors.push(`missing required field '${field}'`)
+      }
+    }
+  }
+
+  // Check property types for provided fields
+  if (schema.properties) {
+    for (const [key, prop] of Object.entries(args)) {
+      const schemaProp = schema.properties[key]
+      if (!schemaProp?.type) continue
+
+      const actualType = Array.isArray(prop) ? 'array' : typeof prop
+      const allowedTypes = Array.isArray(schemaProp.type) ? schemaProp.type : [schemaProp.type]
+
+      // JSON Schema 'integer' maps to JS 'number'
+      const normalizedAllowed = allowedTypes.map((t) => (t === 'integer' ? 'number' : t))
+
+      if (!normalizedAllowed.includes(actualType)) {
+        errors.push(
+          `'${key}' expected ${allowedTypes.join(' | ')}, got ${actualType}`
+        )
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid arguments for ${toolName}: ${errors.join('; ')}`)
+  }
 }
 
 /**

--- a/apps/mcp-server/src/tools/validate-args.test.ts
+++ b/apps/mcp-server/src/tools/validate-args.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { validateArgs } from './types.js'
+
+describe('validateArgs', () => {
+  const schema = {
+    type: 'object' as const,
+    properties: {
+      receiver: { type: 'string', description: 'The receiver address' },
+      amount: { type: 'number', description: 'Amount in microALGO' },
+      note: { type: 'string', description: 'Optional note' },
+    },
+    required: ['receiver', 'amount'],
+  }
+
+  it('passes valid args with all required fields', () => {
+    expect(() =>
+      validateArgs({ receiver: 'ADDR', amount: 1000 }, schema, 'send_payment')
+    ).not.toThrow()
+  })
+
+  it('passes valid args with optional fields', () => {
+    expect(() =>
+      validateArgs(
+        { receiver: 'ADDR', amount: 1000, note: 'hello' },
+        schema,
+        'send_payment'
+      )
+    ).not.toThrow()
+  })
+
+  it('throws on missing required field', () => {
+    expect(() =>
+      validateArgs({ receiver: 'ADDR' }, schema, 'send_payment')
+    ).toThrow("Invalid arguments for send_payment: missing required field 'amount'")
+  })
+
+  it('throws on multiple missing required fields', () => {
+    expect(() => validateArgs({}, schema, 'send_payment')).toThrow(
+      "Invalid arguments for send_payment: missing required field 'receiver'; missing required field 'amount'"
+    )
+  })
+
+  it('throws on wrong type for a field', () => {
+    expect(() =>
+      validateArgs({ receiver: 123, amount: 1000 }, schema, 'send_payment')
+    ).toThrow("'receiver' expected string, got number")
+  })
+
+  it('throws on null required field', () => {
+    expect(() =>
+      validateArgs({ receiver: 'ADDR', amount: null }, schema, 'send_payment')
+    ).toThrow("missing required field 'amount'")
+  })
+
+  it('reports both missing and type errors together', () => {
+    expect(() =>
+      validateArgs({ amount: 'not-a-number' }, schema, 'send_payment')
+    ).toThrow(/missing required field 'receiver'.*'amount' expected number, got string/)
+  })
+
+  it('ignores extra fields not in schema', () => {
+    expect(() =>
+      validateArgs(
+        { receiver: 'ADDR', amount: 1000, extra: true },
+        schema,
+        'send_payment'
+      )
+    ).not.toThrow()
+  })
+
+  it('handles schema with no required fields', () => {
+    const optionalSchema = {
+      type: 'object' as const,
+      properties: {
+        name: { type: 'string' },
+      },
+    }
+    expect(() => validateArgs({}, optionalSchema, 'tool')).not.toThrow()
+  })
+
+  it('handles schema with no properties', () => {
+    const bareSchema = { type: 'object' as const }
+    expect(() => validateArgs({ anything: 42 }, bareSchema, 'tool')).not.toThrow()
+  })
+
+  it('validates integer type as number', () => {
+    const intSchema = {
+      type: 'object' as const,
+      properties: {
+        assetId: { type: 'integer' as const, description: 'Asset ID' },
+      },
+      required: ['assetId'],
+    }
+    // JS typeof returns 'number' for integers — should pass
+    expect(() => validateArgs({ assetId: 42 }, intSchema, 'lookup_asset')).not.toThrow()
+  })
+
+  it('validates array type', () => {
+    const arraySchema = {
+      type: 'object' as const,
+      properties: {
+        transactions: { type: 'array' as const, description: 'Transaction list' },
+      },
+      required: ['transactions'],
+    }
+    expect(() =>
+      validateArgs({ transactions: [{ type: 'payment' }] }, arraySchema, 'send_group')
+    ).not.toThrow()
+
+    expect(() =>
+      validateArgs({ transactions: 'not-an-array' }, arraySchema, 'send_group')
+    ).toThrow("'transactions' expected array, got string")
+  })
+
+  it('validates boolean type', () => {
+    const boolSchema = {
+      type: 'object' as const,
+      properties: {
+        frozen: { type: 'boolean' as const, description: 'Freeze state' },
+      },
+      required: ['frozen'],
+    }
+    expect(() =>
+      validateArgs({ frozen: true }, boolSchema, 'asset_freeze')
+    ).not.toThrow()
+
+    expect(() =>
+      validateArgs({ frozen: 'yes' }, boolSchema, 'asset_freeze')
+    ).toThrow("'frozen' expected boolean, got string")
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `validateArgs()` that checks MCP tool arguments against the tool's `inputSchema` before dispatching to handlers
- Validates required fields are present and property types match the schema definition
- Catches malformed AI-generated arguments early with clear, actionable error messages instead of letting them propagate as cryptic runtime errors deep in the call stack
- Zero changes to existing tool handlers — validation is centralized in `handleToolCall()`

## Changes

- `types.ts`: Added `validateArgs()` function with JSON Schema structural validation (required fields + type checks including `integer` → `number` mapping and `array` detection)
- `index.ts`: Added schema lookup map and `validateArgs()` call before handler dispatch
- `validate-args.test.ts`: 13 unit tests covering all validation paths (missing fields, wrong types, optional fields, edge cases)

## Example error output

Before: tool handler receives `{ amount: "not-a-number" }` and crashes with `TypeError: amount.toString is not a function` or similar deep in Algorand SDK code.

After: `Invalid arguments for send_payment: missing required field 'receiver'; 'amount' expected number, got string`

Fixes #6

🐦‍⬛ Generated with [CorvidAgent](https://github.com/CorvidLabs/corvid-agent)